### PR TITLE
Truncate descriptions in solutions and problems cards

### DIFF
--- a/app/helpers/decidim/challenges/challenges_helper.rb
+++ b/app/helpers/decidim/challenges/challenges_helper.rb
@@ -27,6 +27,11 @@ module Decidim
           challenge.solutions.published
         end
       end
+
+      def truncate_description(description)
+        translated_description = raw translated_attribute description
+        decidim_sanitize(html_truncate(translated_description, length: 200))
+      end
     end
   end
 end

--- a/app/views/decidim/challenges/challenges/show.html.erb
+++ b/app/views/decidim/challenges/challenges/show.html.erb
@@ -92,7 +92,7 @@
                       <%= translated_attribute problem.title %>
                     </div>
                   <% end %>
-                  <%= raw translated_attribute problem.description %>
+                  <%= truncate_description(problem.description) %>
                 </div>
               </div>
             <% end %>
@@ -109,7 +109,7 @@
                     <%= translated_attribute solution.title %>
                   </div>
                 <% end %>
-                <%= raw translated_attribute solution.description %>
+                <%= truncate_description(solution.description) %>
               </div>
             </div>
           <% end %>


### PR DESCRIPTION
When problems and solutions have a long description, they aren't truncated on the cards.

![imagen](https://user-images.githubusercontent.com/75725233/142170607-4dee92d6-d806-449b-ad8a-38cb3b959eff.png)

Now the descriptions are truncated:

![Captura de pantalla de 2021-11-17 09-25-33](https://user-images.githubusercontent.com/75725233/142170965-b39af24b-d6b6-4403-8691-c0d9b712a2bf.png)
