### PR TITLE
Fix order filter in Problems, Challenges and Solutions index

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@ Following Semantic Versioning 2.
 
 ## next version:
 
+## Version 0.0.11 (MINOR)
+- Fix order filter in Challenges, Solutions and Problems.
+
 ## Version 0.0.10 (MINOR)
 - In show Challenge, hide "Keywords" and "Proposed solutions" when they are empty.
 - In show Problem, hide "Keywords" and "Proposed solutions" when they are empty.

--- a/app/controllers/decidim/challenges/challenges_controller.rb
+++ b/app/controllers/decidim/challenges/challenges_controller.rb
@@ -19,7 +19,9 @@ module Decidim
 
       helper_method :challenges
 
-      def index; end
+      def index
+        @challenges = reorder(challenges)
+      end
 
       def show
         @challenge = Challenge.find(params[:id])

--- a/app/controllers/decidim/problems/problems_controller.rb
+++ b/app/controllers/decidim/problems/problems_controller.rb
@@ -19,7 +19,9 @@ module Decidim
 
       helper_method :problems
 
-      def index; end
+      def index
+        @problems = reorder(problems)
+      end
 
       def show
         @problem = Decidim::Problems::Problem.find(params[:id])

--- a/app/controllers/decidim/solutions/solutions_controller.rb
+++ b/app/controllers/decidim/solutions/solutions_controller.rb
@@ -18,7 +18,9 @@ module Decidim
 
       helper_method :solutions
 
-      def index; end
+      def index
+        @solutions = reorder(solutions)
+      end
 
       def show
         @solution = solution

--- a/app/models/decidim/challenges/challenge.rb
+++ b/app/models/decidim/challenges/challenge.rb
@@ -12,6 +12,7 @@ module Decidim
       include Decidim::Traceable
       include Decidim::TranslatableAttributes
       include Decidim::Forms::HasQuestionnaire
+      include Decidim::Randomable
 
       belongs_to :scope,
                  foreign_key: "decidim_scope_id",

--- a/app/models/decidim/problems/problem.rb
+++ b/app/models/decidim/problems/problem.rb
@@ -11,6 +11,7 @@ module Decidim
       include Decidim::Searchable
       include Decidim::Traceable
       include Decidim::TranslatableAttributes
+      include Decidim::Randomable
 
       VALID_STATES = [:proposal, :execution, :finished].freeze
       enum state: VALID_STATES

--- a/app/models/decidim/solutions/solution.rb
+++ b/app/models/decidim/solutions/solution.rb
@@ -11,6 +11,7 @@ module Decidim
       include Decidim::Searchable
       include Decidim::Traceable
       include Decidim::TranslatableAttributes
+      include Decidim::Randomable
 
       component_manifest_name "solutions"
 

--- a/app/views/decidim/challenges/challenges/index.html.erb
+++ b/app/views/decidim/challenges/challenges/index.html.erb
@@ -27,6 +27,6 @@
   </div>
 </div>
 <%= javascript_include_tag("decidim/filters") %>
-<%= javascript_include_tag "decidim/orders" %>
+<%= javascript_include_tag("decidim/results_listing") %>
 
  <%= render partial: "decidim/sdgs/sdgs_filter/modal" %>

--- a/app/views/decidim/solutions/solutions/index.html.erb
+++ b/app/views/decidim/solutions/solutions/index.html.erb
@@ -25,6 +25,6 @@
   </div>
 </div>
 <%= javascript_include_tag("decidim/filters") %>
-<%= javascript_include_tag "decidim/orders" %>
+<%= javascript_include_tag("decidim/results_listing") %>
 
 <%= render partial: "decidim/sdgs/sdgs_filter/modal" %>

--- a/lib/decidim/challenges/version.rb
+++ b/lib/decidim/challenges/version.rb
@@ -4,7 +4,7 @@ module Decidim
   # This holds the decidim-meetings version.
   module Challenges
     def self.version
-      "0.0.10"
+      "0.0.11"
     end
 
     def self.decidim_version

--- a/spec/system/decidim/challenges/challenges_spec.rb
+++ b/spec/system/decidim/challenges/challenges_spec.rb
@@ -45,4 +45,37 @@ describe "Challenges", type: :system do
       end
     end
   end
+
+  describe("#index") do
+    context "when list all challenges" do
+      let!(:older_challenge) { create(:challenge, component: component, created_at: 1.month.ago) }
+      let!(:recent_challenge) { create(:challenge, component: component, created_at: Time.now.utc) }
+      let!(:challenges) { create_list(:challenge, 2, component: component) }
+
+      before do
+        visit_component
+      end
+
+      it "ordered randomly" do
+        within ".order-by" do
+          expect(page).to have_selector("ul[data-dropdown-menu$=dropdown-menu]", text: "Random")
+        end
+
+        expect(page).to have_selector(".card--challenge", count: 4)
+        expect(page).to have_content(translated(challenges.first.title))
+        expect(page).to have_content(translated(challenges.last.title))
+      end
+
+      it "ordered by created at" do
+        within ".order-by" do
+          expect(page).to have_selector("ul[data-dropdown-menu$=dropdown-menu]", text: "Random")
+          page.find("a", text: "Random").click
+          click_link "Most recent"
+        end
+
+        expect(page).to have_selector("#challenges .card-grid .column:first-child", text: recent_challenge.title[:en])
+        expect(page).to have_selector("#challenges .card-grid .column:last-child", text: older_challenge.title[:en])
+      end
+    end
+  end
 end

--- a/spec/system/decidim/problems/problems_spec.rb
+++ b/spec/system/decidim/problems/problems_spec.rb
@@ -40,4 +40,37 @@ describe "Problems", type: :system do
       end
     end
   end
+
+  describe("#index") do
+    context "when list all problems" do
+      let!(:older_problem) { create(:problem, component: component, created_at: 1.month.ago) }
+      let!(:recent_problem) { create(:problem, component: component, created_at: Time.now.utc) }
+      let!(:problems) { create_list(:problem, 2, component: component) }
+
+      before do
+        visit_component
+      end
+
+      it "ordered randomly" do
+        within ".order-by" do
+          expect(page).to have_selector("ul[data-dropdown-menu$=dropdown-menu]", text: "Random")
+        end
+
+        expect(page).to have_selector(".card--problem", count: 4)
+        expect(page).to have_content(translated(problems.first.title))
+        expect(page).to have_content(translated(problems.last.title))
+      end
+
+      it "ordered by created at" do
+        within ".order-by" do
+          expect(page).to have_selector("ul[data-dropdown-menu$=dropdown-menu]", text: "Random")
+          page.find("a", text: "Random").click
+          click_link "Most recent"
+        end
+
+        expect(page).to have_selector("#problems .card-grid .column:first-child", text: recent_problem.title[:en])
+        expect(page).to have_selector("#problems .card-grid .column:last-child", text: older_problem.title[:en])
+      end
+    end
+  end
 end

--- a/spec/system/decidim/solutions/solutions_spec.rb
+++ b/spec/system/decidim/solutions/solutions_spec.rb
@@ -51,4 +51,37 @@ describe "Solutions", type: :system do
       end
     end
   end
+
+  describe("#index") do
+    context "when list all solutions" do
+      let!(:older_solution) { create(:solution, component: component, created_at: 1.month.ago) }
+      let!(:recent_solution) { create(:solution, component: component, created_at: Time.now.utc) }
+      let!(:solutions) { create_list(:solution, 2, component: component) }
+
+      before do
+        visit_component
+      end
+
+      it "ordered randomly" do
+        within ".order-by" do
+          expect(page).to have_selector("ul[data-dropdown-menu$=dropdown-menu]", text: "Random")
+        end
+
+        expect(page).to have_selector(".card--solution", count: 4)
+        expect(page).to have_content(translated(solutions.first.title))
+        expect(page).to have_content(translated(solutions.last.title))
+      end
+
+      it "ordered by created at" do
+        within ".order-by" do
+          expect(page).to have_selector("ul[data-dropdown-menu$=dropdown-menu]", text: "Random")
+          page.find("a", text: "Random").click
+          click_link "Most recent"
+        end
+
+        expect(page).to have_selector("#solutions .card-grid .column:first-child", text: recent_solution.title[:en])
+        expect(page).to have_selector("#solutions .card-grid .column:last-child", text: older_solution.title[:en])
+      end
+    end
+  end
 end


### PR DESCRIPTION
Order filter in Problem, Challenges and Solutions list not works.

- Add reorder in index
- Include Decidim::Randomable in models
- Change orders.js to results_listing.js. order.js is deprecate.