### PR TITLE
fix: assets compilations

### DIFF
--- a/app/packs/entrypoints/decidim_sdgs.scss
+++ b/app/packs/entrypoints/decidim_sdgs.scss
@@ -1,1 +1,1 @@
-@import "stylesheets/decidim/sdgs/ods.scss";
+@import "stylesheets/decidim/sdgs/ods";

--- a/app/packs/stylesheets/decidim/sdgs/ods.scss
+++ b/app/packs/stylesheets/decidim/sdgs/ods.scss
@@ -6,7 +6,6 @@
   src: url('../fonts/Oswald-Medium.ttf')
 }
 
-
 #ods-logo-container {
   width: 250px;
   height: 250px;

--- a/lib/decidim/challenges/version.rb
+++ b/lib/decidim/challenges/version.rb
@@ -4,11 +4,11 @@ module Decidim
   # This holds the decidim-meetings version.
   module Challenges
     def self.version
-      "0.2.0"
+      "0.2.1"
     end
 
     def self.decidim_version
-      "~> 0.26.2"
+      "~> 0.26.4"
     end
   end
 end

--- a/lib/decidim/sdgs/component.rb
+++ b/lib/decidim/sdgs/component.rb
@@ -10,6 +10,7 @@ Decidim.register_component(:sdgs) do |component|
   component.engine = Decidim::Sdgs::Engine
   component.admin_engine = Decidim::Sdgs::AdminEngine
   component.icon = "media/images/decidim_challenges_icon.svg"
+  component.stylesheet = "decidim/sdgs/sdgs"
 
   # component.on(:before_destroy) do |instance|
   #   # Code executed before removing the component


### PR DESCRIPTION
- add `component.stylesheet` in sdgs components like the other ones.
- don't use `.scss` extensions in imports.
- update decidim version to last stable (0.26.4)
- bump minor version

=== 

Details: 
On installing this module on a fresh 0.26.4 installations, we found some issues regarding scss imports for sdgs: 

```
ActionView::Template::Error (Webpacker can't find decidim/decidim_sdgs.scss in /$HOME/public/decidim-packs/manifest.json. Possible causes:
```