### PR TITLE
Fix update challenge with card image

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@ Following Semantic Versioning 2.
 
 ## next version:
 
+## Version 0.3.3 (PATCH)
+- Fix update challenge with a card image
+
 ## Version 0.3.2 (PATCH)
 - Fix card image validation in Challenges Form.
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -174,7 +174,7 @@ GIT
 PATH
   remote: .
   specs:
-    decidim-challenges (0.3.2)
+    decidim-challenges (0.3.3)
       decidim-core (~> 0.27)
 
 GEM

--- a/app/commands/decidim/challenges/admin/update_challenge.rb
+++ b/app/commands/decidim/challenges/admin/update_challenge.rb
@@ -5,6 +5,8 @@ module Decidim
     module Admin
       # A command with all the business logic when a user updates a challenge.
       class UpdateChallenge < Decidim::Command
+        include ::Decidim::AttachmentAttributesMethods
+
         # Public: Initializes the command.
         #
         # form         - A form object with the params.
@@ -60,8 +62,9 @@ module Decidim
             end_date: form.end_date,
             coordinating_entities: form.coordinating_entities,
             collaborating_entities: form.collaborating_entities,
-            card_image: form.card_image,
-          }
+          }.merge(
+            attachment_attributes(:card_image)
+          )
         end
       end
     end

--- a/lib/decidim/challenges/version.rb
+++ b/lib/decidim/challenges/version.rb
@@ -4,7 +4,7 @@ module Decidim
   # This holds the decidim-meetings version.
   module Challenges
     def self.version
-      "0.3.2"
+      "0.3.3"
     end
 
     def self.decidim_version


### PR DESCRIPTION
When you update a challenge with an image, the image is lost.

The problem in the update command has been fixed.